### PR TITLE
Add return_X_y parameter to all fetchers.

### DIFF
--- a/skdatasets/repositories/cran.py
+++ b/skdatasets/repositories/cran.py
@@ -328,20 +328,22 @@ def _to_sklearn(dataset, *, target_name):
     )
 
 
-def fetch(name):
-    """Load
-
-    Load a dataset.
+def fetch(name, *, return_X_y=False):
+    """Load a dataset.
 
     Parameters
     ----------
     name : string
         Dataset name.
+    return_X_y : bool, default=False
+        If True, returns ``(data, target)`` instead of a Bunch object.
 
     Returns
     -------
     data : Bunch
           Dictionary-like object with all the data and metadata.
+
+    (data, target) : tuple if ``return_X_y`` is True
 
     """
     load_args = datasets[name]['load_args']
@@ -349,4 +351,8 @@ def fetch(name):
 
     sklearn_args = datasets[name]['sklearn_args']
     sklearn_dataset = _to_sklearn(dataset, *sklearn_args[0], **sklearn_args[1])
+
+    if return_X_y:
+        return sklearn_dataset.data, sklearn_dataset.target
+
     return sklearn_dataset

--- a/skdatasets/repositories/forex.py
+++ b/skdatasets/repositories/forex.py
@@ -49,7 +49,7 @@ def _load_forex(start=date(2015, 1, 1), end=date.today(), currency_1='USD',
 
 
 def fetch(start=date(2015, 1, 1), end=date.today(), currency_1='USD',
-          currency_2='EUR'):
+          currency_2='EUR', return_X_y=False):
     """Fetch Forex datasets.
 
     Fetches the ECB Forex and Coindesk Bitcoin datasets. More info at
@@ -65,11 +65,15 @@ def fetch(start=date(2015, 1, 1), end=date.today(), currency_1='USD',
         Currency 1.
     currency_2 : str, default='EUR'
         Currency 2.
+    return_X_y : bool, default=False
+        If True, returns ``(data, target)`` instead of a Bunch object.
 
     Returns
     -------
     data : Bunch
         Dictionary-like object with all the data and metadata.
+
+    (data, target) : tuple if ``return_X_y`` is True
 
     """
     if currency_1 == 'BTC':
@@ -83,6 +87,10 @@ def fetch(start=date(2015, 1, 1), end=date.today(), currency_1='USD',
                         currency_2=currency_2)
         descr = str(currency_1) + '-' + str(currency_2)
     descr = descr + start.strftime('%Y-%m-%d') + '-' + end.strftime('%Y-%m-%d')
+
+    if return_X_y:
+        return X, None
+
     return Bunch(
         data=X,
         target=None,

--- a/skdatasets/repositories/keel.py
+++ b/skdatasets/repositories/keel.py
@@ -148,7 +148,8 @@ def _load_folds(collection, name, nfolds, dobscv, nattrs, data_home=None):
     return X, y, cv
 
 
-def fetch(collection, name, data_home=None, nfolds=None, dobscv=False):
+def fetch(collection, name, data_home=None, nfolds=None, dobscv=False, *,
+          return_X_y=False):
     """Fetch Keel dataset.
 
     Fetch a Keel dataset by collection and name. More info at
@@ -169,6 +170,8 @@ def fetch(collection, name, data_home=None, nfolds=None, dobscv=False):
     dobscv : bool, default=False
         If folds are in {5, 10}, indicates that the cv folds are distribution
         optimally balanced stratified. Only available for some datasets.
+    return_X_y : bool, default=False
+        If True, returns ``(data, target)`` instead of a Bunch object.
     **kwargs : dict
         Optional key-value arguments
 
@@ -177,13 +180,19 @@ def fetch(collection, name, data_home=None, nfolds=None, dobscv=False):
     data : Bunch
         Dictionary-like object with all the data and metadata.
 
+    (data, target) : tuple if ``return_X_y`` is True
+
     """
     if collection not in COLLECTIONS:
         raise Exception('Avaliable collections are ' + str(list(COLLECTIONS)))
     nattrs, DESCR = _load_descr(collection, name, data_home=data_home)
     X, y, cv = _load_folds(collection, name, nfolds, dobscv, nattrs,
                            data_home=data_home)
-    data = Bunch(
+
+    if return_X_y:
+        return X, y
+
+    return Bunch(
         data=X,
         target=y,
         train_indices=[],
@@ -193,4 +202,3 @@ def fetch(collection, name, data_home=None, nfolds=None, dobscv=False):
         outer_cv=cv,
         DESCR=DESCR,
     )
-    return data

--- a/skdatasets/repositories/keras.py
+++ b/skdatasets/repositories/keras.py
@@ -17,7 +17,7 @@ DATASETS = {'boston_housing': boston_housing.load_data,
             'mnist': mnist.load_data, 'reuters': reuters.load_data}
 
 
-def fetch(name, **kwargs):
+def fetch(name, *, return_X_y=False, **kwargs):
     """Fetch Keras dataset.
 
     Fetch a Keras dataset by name. More info at https://keras.io/datasets.
@@ -26,6 +26,8 @@ def fetch(name, **kwargs):
     ----------
     name : string
         Dataset name.
+    return_X_y : bool, default=False
+        If True, returns ``(data, target)`` instead of a Bunch object.
     **kwargs : dict
         Optional key-value arguments. See https://keras.io/datasets.
 
@@ -33,6 +35,8 @@ def fetch(name, **kwargs):
     -------
     data : Bunch
         Dictionary-like object with all the data and metadata.
+
+    (data, target) : tuple if ``return_X_y`` is True
 
     """
     (X_train, y_train), (X_test, y_test) = DATASETS[name](**kwargs)
@@ -45,6 +49,9 @@ def fetch(name, **kwargs):
 
     X = np.concatenate((X_train, X_test))
     y = np.concatenate((y_train, y_test))
+
+    if return_X_y:
+        return X, y
 
     return Bunch(
         data=X,

--- a/skdatasets/repositories/libsvm.py
+++ b/skdatasets/repositories/libsvm.py
@@ -150,7 +150,7 @@ def _load(collection, name, data_home=None):
     return X, y, train_indices, validation_indices, test_indices, cv
 
 
-def fetch(collection, name, data_home=None):
+def fetch(collection, name, data_home=None, *, return_X_y=False):
     """Fetch LIBSVM dataset.
 
     Fetch a LIBSVM dataset by collection and name. More info at
@@ -165,11 +165,15 @@ def fetch(collection, name, data_home=None):
     data_home : string or None, default None
         Specify another download and cache folder for the data sets. By default
         all scikit-learn data is stored in ‘~/scikit_learn_data’ subfolders.
+    return_X_y : bool, default=False
+        If True, returns ``(data, target)`` instead of a Bunch object.
 
     Returns
     -------
     data : Bunch
         Dictionary-like object with all the data and metadata.
+
+    (data, target) : tuple if ``return_X_y`` is True
 
     """
     if collection not in COLLECTIONS:
@@ -181,7 +185,10 @@ def fetch(collection, name, data_home=None):
         data_home=data_home,
     )
 
-    data = Bunch(
+    if return_X_y:
+        return X, y
+
+    return Bunch(
         data=X,
         target=y,
         train_indices=train_indices,
@@ -191,5 +198,3 @@ def fetch(collection, name, data_home=None):
         outer_cv=None,
         DESCR=name,
     )
-
-    return data

--- a/skdatasets/repositories/raetsch.py
+++ b/skdatasets/repositories/raetsch.py
@@ -57,7 +57,7 @@ def _fetch_remote(data_home=None):
     return file_path
 
 
-def fetch(name, data_home=None):
+def fetch(name, data_home=None, *, return_X_y=False):
     """Fetch Gunnar Raetsch's dataset.
 
     Fetch a Gunnar Raetsch's benchmark dataset by name. Availabe datasets are
@@ -73,11 +73,15 @@ def fetch(name, data_home=None):
     data_home : string or None, default None
         Specify another download and cache folder for the data sets. By default
         all scikit-learn data is stored in ‘~/scikit_learn_data’ subfolders.
+    return_X_y : bool, default=False
+        If True, returns ``(data, target)`` instead of a Bunch object.
 
     Returns
     -------
     data : Bunch
         Dictionary-like object with all the data and metadata.
+
+    (data, target) : tuple if ``return_X_y`` is True
 
     """
     if name not in DATASETS:
@@ -86,6 +90,9 @@ def fetch(name, data_home=None):
     X, y, train_splits, test_splits = loadmat(filename)[name][0][0]
     cv = ((X[tr - 1], y[tr - 1], X[ts - 1], y[ts - 1])
           for tr, ts in zip(train_splits, test_splits))
+
+    if return_X_y:
+        return X, y
 
     return Bunch(
         data=X,

--- a/skdatasets/repositories/sklearn.py
+++ b/skdatasets/repositories/sklearn.py
@@ -48,7 +48,7 @@ DATASETS = {'20newsgroups': fetch_20newsgroups,
             'wine': load_wine}
 
 
-def fetch(name, **kwargs):
+def fetch(name, *, return_X_y=False, **kwargs):
     """Fetch Scikit-learn dataset.
 
     Fetch a Scikit-learn dataset by name. More info at
@@ -58,6 +58,8 @@ def fetch(name, **kwargs):
     ----------
     name : string
         Dataset name.
+    return_X_y : bool, default=False
+        If True, returns ``(data, target)`` instead of a Bunch object.
     **kwargs : dict
         Optional key-value arguments. See
         scikit-learn.org/stable/modules/classes.html#module-sklearn.datasets.
@@ -67,12 +69,19 @@ def fetch(name, **kwargs):
     data : Bunch
         Dictionary-like object with all the data and metadata.
 
+    (data, target) : tuple if ``return_X_y`` is True
+
     """
+    if return_X_y:
+        kwargs["return_X_y"] = True
+
     data = DATASETS[name](**kwargs)
-    data.train_indices = []
-    data.validation_indices = []
-    data.test_indices = []
-    data.inner_cv = None
-    data.outer_cv = None
+
+    if not return_X_y:
+        data.train_indices = []
+        data.validation_indices = []
+        data.test_indices = []
+        data.inner_cv = None
+        data.outer_cv = None
 
     return data

--- a/skdatasets/repositories/uci.py
+++ b/skdatasets/repositories/uci.py
@@ -73,7 +73,7 @@ def _fetch(name, data_home=None):
     return X, y, X_test, y_test, fdescr
 
 
-def fetch(name, data_home=None):
+def fetch(name, data_home=None, *, return_X_y=False):
     """Fetch UCI dataset.
 
     Fetch a UCI dataset by name. More info at
@@ -86,11 +86,15 @@ def fetch(name, data_home=None):
     data_home : string or None, default None
         Specify another download and cache folder for the data sets. By default
         all scikit-learn data is stored in ‘~/scikit_learn_data’ subfolders.
+    return_X_y : bool, default=False
+        If True, returns ``(data, target)`` instead of a Bunch object.
 
     Returns
     -------
     data : Bunch
         Dictionary-like object with all the data and metadata.
+
+    (data, target) : tuple if ``return_X_y`` is True
 
     """
     X_train, y_train, X_test, y_test, DESCR = _fetch(name, data_home=data_home)
@@ -108,7 +112,10 @@ def fetch(name, data_home=None):
         train_indices = list(range(len(X_train)))
         test_indices = list(range(len(X_train), len(X)))
 
-    data = Bunch(
+    if return_X_y:
+        return X, y
+
+    return Bunch(
         data=X,
         target=y,
         train_indices=train_indices,
@@ -118,4 +125,3 @@ def fetch(name, data_home=None):
         outer_cv=None,
         DESCR=DESCR,
     )
-    return data

--- a/skdatasets/repositories/ucr.py
+++ b/skdatasets/repositories/ucr.py
@@ -53,7 +53,30 @@ def data_to_matrix(struct_array):
         return np.array(struct_array.tolist())
 
 
-def fetch(name, data_home=None):
+def fetch(name, data_home=None, *, return_X_y=False):
+    """Fetch UCR dataset.
+
+    Fetch a UCR dataset by name. More info at
+    http://www.timeseriesclassification.com/.
+
+    Parameters
+    ----------
+    name : string
+        Dataset name.
+    data_home : string or None, default None
+        Specify another download and cache folder for the data sets. By default
+        all scikit-learn data is stored in ‘~/scikit_learn_data’ subfolders.
+    return_X_y : bool, default=False
+        If True, returns ``(data, target)`` instead of a Bunch object.
+
+    Returns
+    -------
+    data : Bunch
+        Dictionary-like object with all the data and metadata.
+
+    (data, target) : tuple if ``return_X_y`` is True
+
+    """
     url = BASE_URL + name
 
     data_home = _fetch_zip(name, urlname=url + '.zip', subfolder="ucr",
@@ -90,6 +113,9 @@ def fetch(name, data_home=None):
 
     X = np.concatenate((X_train, X_test))
     y = np.concatenate((y_train, y_test))
+
+    if return_X_y:
+        return X, y
 
     return Bunch(
         data=X,

--- a/tests/repositories/test_cran.py
+++ b/tests/repositories/test_cran.py
@@ -11,3 +11,8 @@ from skdatasets.repositories.cran import fetch
 def test_cran_geyser():
     """Tests CRAN geyser dataset."""
     fetch('geyser')
+
+
+def test_cran_geyser_return_X_y():
+    """Tests CRAN geyser dataset."""
+    X, y = fetch('geyser', return_X_y=True)

--- a/tests/repositories/test_forex.py
+++ b/tests/repositories/test_forex.py
@@ -16,6 +16,15 @@ def test_forex_usd_eur():
                  currency_1='USD', currency_2='EUR')
     assert data.data.shape == (31, 1)
 
+
+def test_forex_usd_eur_return_X_y():
+    """Tests forex USD-EUR dataset."""
+    X, y = fetch(start=date(2015, 1, 1), end=date(2015, 1, 31),
+                 currency_1='USD', currency_2='EUR', return_X_y=True)
+    assert X.shape == (31, 1)
+    assert y is None
+
+
 def test_forex_btc_eur():
     """Tests forex BTC-EUR dataset."""
     data = fetch(start=date(2015, 1, 1), end=date(2015, 1, 31),

--- a/tests/repositories/test_keel.py
+++ b/tests/repositories/test_keel.py
@@ -31,6 +31,13 @@ def test_fetch_keel_abalone9_18():
     check(data, (731, 10))
 
 
+def test_fetch_keel_abalone9_18_return_X_y():
+    """Tests Keel abalone9-18 dataset."""
+    X, y = fetch('imbalanced', 'abalone9-18', return_X_y=True)
+    assert X.shape == (731, 10)
+    assert y.shape == (731,)
+
+
 def test_fetch_keel_abalone9_18_folds():
     """Tests Keel abalone9-18 dataset with folds."""
     data = fetch('imbalanced', 'abalone9-18', nfolds=5)

--- a/tests/repositories/test_keras.py
+++ b/tests/repositories/test_keras.py
@@ -23,3 +23,10 @@ def test_keras_mnist():
     """Tests keras MNIST dataset."""
     data = fetch('mnist')
     check(data, n_samples_train=60000, n_samples_test=10000, n_features=28 * 28)
+
+
+def test_keras_mnist_return_X_y():
+    """Tests keras MNIST dataset."""
+    X, y = fetch('mnist', return_X_y=True)
+    assert X.shape == (70000, 28 * 28)
+    assert y.shape == (70000,)

--- a/tests/repositories/test_libsvm.py
+++ b/tests/repositories/test_libsvm.py
@@ -64,6 +64,13 @@ def test_fetch_libsvm_australian():
     check(data, n_samples=690, n_features=14)
 
 
+def test_fetch_libsvm_australian_return_X_y():
+    """Tests LIBSVM australian dataset."""
+    X, y = fetch('binary', 'australian', return_X_y=True)
+    assert X.shape == (690, 14)
+    assert y.shape == (690,)
+
+
 def test_fetch_libsvm_liver_disorders():
     """Tests LIBSVM liver-disorders dataset."""
     data = fetch('binary', 'liver-disorders')

--- a/tests/repositories/test_raetsch.py
+++ b/tests/repositories/test_raetsch.py
@@ -5,9 +5,9 @@ Test the Raetsch loader.
 @license: MIT
 """
 
-from . import check_estimator
-
 from skdatasets.repositories.raetsch import fetch
+
+from . import check_estimator
 
 
 def check(data, shape, splits=100):
@@ -22,3 +22,10 @@ def test_fetch_raetsch_banana():
     """Tests Gunnar Raetsch banana dataset."""
     data = fetch('banana')
     check(data, (5300, 2), splits=100)
+
+
+def test_fetch_raetsch_banana_return_X_y():
+    """Tests Gunnar Raetsch banana dataset."""
+    X, y = fetch('banana', return_X_y=True)
+    assert X.shape == (5300, 2)
+    assert y.shape == (5300, 1)

--- a/tests/repositories/test_sklearn.py
+++ b/tests/repositories/test_sklearn.py
@@ -5,9 +5,9 @@ Test the Scikit-learn loader.
 @license: MIT
 """
 
-from . import check_estimator
-
 from skdatasets.repositories.sklearn import fetch
+
+from . import check_estimator
 
 
 def test_sklearn_iris():
@@ -15,3 +15,10 @@ def test_sklearn_iris():
     data = fetch('iris')
     assert data.data.shape == (150, 4)
     check_estimator(data)
+
+
+def test_sklearn_iris_return_X_y():
+    """Tests Scikit-learn iris dataset."""
+    X, y = fetch('iris', return_X_y=True)
+    assert X.shape == (150, 4)
+    assert y.shape == (150,)

--- a/tests/repositories/test_uci.py
+++ b/tests/repositories/test_uci.py
@@ -18,3 +18,10 @@ def test_fetch_uci_wine():
     assert not data.test_indices
     assert data.inner_cv is None
     assert data.outer_cv is None
+
+
+def test_fetch_uci_wine_return_X_y():
+    """Tests UCI wine dataset."""
+    X, y = fetch('wine', return_X_y=True)
+    assert X.shape == (178, 13)
+    assert y.shape == (178,)

--- a/tests/repositories/test_ucr.py
+++ b/tests/repositories/test_ucr.py
@@ -14,3 +14,10 @@ def test_fetch_ucr_gunpoint():
     assert data.data.shape == (200, 150)
     assert len(data.train_indices) == 50
     assert len(data.test_indices) == 150
+
+
+def test_fetch_ucr_gunpoint_return_X_y():
+    """Tests UCR GunPoint dataset."""
+    X, y = fetch('GunPoint', return_X_y=True)
+    assert X.shape == (200, 150)
+    assert y.shape == (200,)


### PR DESCRIPTION
Adds a `return_X_y` parameter to all fetchers, that allows them to return a tuple with only the data and target. This is an option that was added to the scikit-learn interface for fetchers in https://github.com/scikit-learn/scikit-learn/issues/6670.